### PR TITLE
Include license file in the packaged crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ include = [
   "**/*.rs",
   "Cargo.toml",
   "COMMANDS.md",
-  "COMMANDS_SHORT.md"
+  "COMMANDS_SHORT.md",
+  "LICENSE.txt"
 ]
 
 [features]


### PR DESCRIPTION
The MIT license requires the text to be included when distributing, this ensures it's included in the package crate.