### PR TITLE
fix: Typos in redo error message and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This project is essentially built upon the regex crate, as regex is the heart of
 
 ## Contributing:
 
-There are two main contributions welcomed as of now.
+There are four main contributions welcomed as of now.
 
 1. Adding tests. Though core uses for command are tested, more behaviours should
    be validated. If you have the time, add test cases that validate that:

--- a/src/error/display.rs
+++ b/src/error/display.rs
@@ -61,7 +61,7 @@ impl std::fmt::Display for EdError {
         relative_undo_limit,
       ),
       HistoryIndexTooBig{index, history_len, relative_redo_limit} => write!(f,
-        "Tried to redo beyond existing snapshots.\nHigest valid nr of redo steps is {}.\n(Given index: {}, Highest valid index: {})",
+        "Tried to redo beyond existing snapshots.\nHighest valid nr of redo steps is {}.\n(Given index: {}, Highest valid index: {})",
         relative_redo_limit,
         index,
         history_len - 1,


### PR DESCRIPTION
Two one-word fixes found while reading through the code.
  - changed Higest to Highest in UndoIndexTooBig message
  - changed "two main contributions" to "four..." to align with the four bullets below it
